### PR TITLE
Fix configure for recent cURL versions

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -5,10 +5,15 @@ ARG_WITH("oauth", "oAuth support", "no");
 if (PHP_OAUTH != "no") {
 	if (CHECK_LIB("libcurl_a.lib;libcurl.lib", "oauth", PHP_OAUTH) &&
 			CHECK_HEADER_ADD_INCLUDE("curl/easy.h", "CFLAGS_OAUTH") &&
-			CHECK_LIB("ssleay32.lib", "oauth", PHP_OAUTH) &&
-			CHECK_LIB("libeay32.lib", "oauth", PHP_OAUTH) 
+			(CHECK_LIB("libcrypto.lib", "oauth", PHP_OAUTH) &&
+			 CHECK_LIB("libssl.lib", "oauth", PHP_OAUTH) ||
+			 CHECK_LIB("ssleay32.lib", "oauth", PHP_OAUTH) &&
+			 CHECK_LIB("libeay32.lib", "oauth", PHP_OAUTH)) &&
+			CHECK_LIB("libssh2.lib", "oauth", PHP_OAUTH) &&
+			CHECK_LIB("nghttp2.lib", "oauth", PHP_OAUTH)
 		&& CHECK_LIB("winmm.lib", "oauth", PHP_OAUTH)
 		&& CHECK_LIB("wldap32.lib", "oauth", PHP_OAUTH)
+		&& CHECK_LIB("Normaliz.lib", "oauth", PHP_OAUTH)
 		&& (((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib", "oauth", PHP_OAUTH) ||  CHECK_LIB("zlib.lib", "oauth", PHP_OAUTH))) || 
 			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "oauth", PHP_OAUTH)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED)))
 		) {


### PR DESCRIPTION
Recent official winlibs/curl releases use libssh2.lib, nghttp2.lib and
Normaliz.lib; the PHP-7.2+ variants use OpenSSL 1.1, i.e. libcrypto.lib
and libssl.lib instead of ssleay32.lib and libeay32.lib.  So we have to
add these to the build.