### PR TITLE
[PHP 7.4] replace uint-uint32_t, ulong-zend_ulong

### DIFF
--- a/oauth.c
+++ b/oauth.c
@@ -416,7 +416,7 @@ int oauth_http_build_query(php_so_object *soo, smart_string *s, HashTable *args,
 	zval *cur_val;
 	zend_string *cur_key, *arg_key, *param_value;
 	int numargs = 0, hash_key_type, skip_append = 0, i, found;
-	ulong num_index;
+	zend_ulong num_index;
 	HashPosition pos;
 	smart_string keyname;
 
@@ -717,7 +717,7 @@ void oauth_add_signature_header(HashTable *request_headers, HashTable *oauth_arg
 	zval *curval;
 	zend_string *param_name, *param_val;
 	zend_string *cur_key;
-	ulong num_key;
+	zend_ulong num_key;
 	HashPosition pos;
 
 	smart_string_appends(&sheader, "OAuth ");
@@ -806,7 +806,7 @@ static long make_req_streams(php_so_object *soo, const char *url, const smart_st
 		HashPosition pos;
 		zval *cur_val, zheaders;
 		zend_string *cur_key;
-		ulong num_key;
+		zend_ulong num_key;
 		smart_string sheaders = {0};
 		int first = 1;
 
@@ -945,7 +945,7 @@ static long make_req_streams(php_so_object *soo, const char *url, const smart_st
 #if OAUTH_USE_CURL
 static size_t soo_read_response(char *ptr, size_t size, size_t nmemb, void *ctx) /* {{{ */
 {
-	uint relsize;
+	size_t relsize;
 	php_so_object *soo = (php_so_object *)ctx;
 
 	relsize = size * nmemb;
@@ -1044,8 +1044,8 @@ long make_req_curl(php_so_object *soo, const char *url, const smart_string *payl
 	double d_code;
 	zval info, *zca_info, *zca_path, *cur_val;
 	char *s_code, *content_type = NULL, *bufz = NULL;
-	uint sslcheck;
-	ulong num_key;
+	uit32_t sslcheck;
+	zend_ulong num_key;
 	smart_string sheader = {0};
 	zend_string *cur_key;
 	HashPosition pos;
@@ -1412,7 +1412,7 @@ static long oauth_fetch(php_so_object *soo, const char *url, const char *method,
 	HashTable *rargs = NULL, *rheaders = NULL;
 	long http_response_code, auth_type;
 	smart_string surl = {0}, payload = {0}, postdata = {0};
-	uint is_redirect = FALSE, follow_redirects = 0, need_to_free_rheaders = 0;
+	uit32_t is_redirect = FALSE, follow_redirects = 0, need_to_free_rheaders = 0;
 
 	auth_type = Z_LVAL_P(soo_get_property(soo, OAUTH_ATTR_AUTHMETHOD));
 	if(fetch_flags & OAUTH_OVERRIDE_HTTP_METHOD) {

--- a/php_oauth.h
+++ b/php_oauth.h
@@ -216,12 +216,12 @@ typedef struct {
 	smart_string headers_in;
 	smart_string headers_out;
 	char last_location_header[OAUTH_MAX_HEADER_LEN];
-	uint redirects;
-	uint multipart_files_num;
-	uint sslcheck; /* whether we check for SSL verification or not */
-	uint debug; /* verbose output */
-	uint follow_redirects; /* follow and sign redirects? */
-	uint reqengine; /* streams or curl */
+	uit32_t redirects;
+	uit32_t multipart_files_num;
+	uit32_t sslcheck; /* whether we check for SSL verification or not */
+	uit32_t debug; /* verbose output */
+	uit32_t follow_redirects; /* follow and sign redirects? */
+	uit32_t reqengine; /* streams or curl */
 	long timeout; /* timeout in milliseconds */
 	char *nonce;
 	char *timestamp;
@@ -232,7 +232,7 @@ typedef struct {
 	php_so_debug *debug_info;
 	char **multipart_files;
 	char **multipart_params;
-	uint is_multipart;
+	uit32_t is_multipart;
 	void ***thread_ctx;
 	zend_object zo;
 } php_so_object;

--- a/provider.c
+++ b/provider.c
@@ -58,7 +58,7 @@ static int oauth_provider_remove_required_param(HashTable *ht, char *required_pa
 {
 	zval *dest_entry;
 	zend_string *key;
-	ulong num_key;
+	zend_ulong num_key;
 	HashPosition hpos;
 
 	if((dest_entry = zend_hash_str_find(ht, required_param, strlen(required_param))) == NULL) {
@@ -97,7 +97,7 @@ static void oauth_provider_apply_custom_param(HashTable *ht, HashTable *custom) 
 	HashPosition custompos;
 	zval *entry;
 	zend_string *key;
-	ulong num_key;
+	zend_ulong num_key;
 
 	zend_hash_internal_pointer_reset_ex(custom, &custompos);
 	do {
@@ -156,7 +156,7 @@ static void oauth_provider_check_required_params(HashTable *required_params, Has
 	HashPosition hpos, reqhpos, paramhpos;
 	zval *dest_entry, param;
 	zend_string *key;
-	ulong num_key;
+	zend_ulong num_key;
 
 	zend_hash_internal_pointer_reset_ex(required_params, &hpos);
 	zend_hash_internal_pointer_reset_ex(params, &reqhpos);
@@ -451,7 +451,7 @@ SOP_METHOD(__construct)
 	zval *params = NULL, *pthis = NULL, apache_get_headers, retval, *tmpzval, *item_param;
 	char *authorization_header = NULL;
 	zend_string *key;
-	ulong num_key = 0, param_count = 0;
+	zend_ulong num_key = 0, param_count = 0;
 	HashPosition hpos;
 
 	pthis = getThis();
@@ -662,7 +662,7 @@ SOP_METHOD(checkOAuthRequest)
 	zval *retval = NULL, *param, *pthis, *token_secret = NULL, *consumer_secret, *req_signature, *sig_method = NULL, rv;
 	oauth_sig_context *sig_ctx = NULL;
 	php_oauth_provider *sop;
-	ulong missing_param_count = 0, mp_count = 1;
+	zend_ulong missing_param_count = 0, mp_count = 1;
 	char additional_info[512] = "", *http_verb = NULL, *uri = NULL, *current_uri = NULL;
 	zend_string *sbs, *signature = NULL;
 	HashPosition hpos;
@@ -974,8 +974,8 @@ SOP_METHOD(reportProblem)
 	zend_bool out_malloced = 0;
 	char *out, *tmp_out, *http_header_line;
 	size_t pr_len;
-	ulong lcode;
-	uint http_code;
+	zend_ulong lcode;
+	uit32_t http_code;
 	sapi_header_line ctr = {0};
 	zend_bool send_headers = 1;
 


### PR DESCRIPTION
New PR, because the previous one had conflicts with https://github.com/php/pecl-web_services-oauth/pull/7 that was merged by @rlerdorf 

I added the change by @nikic in https://github.com/php/pecl-web_services-oauth/pull/5#discussion_r295170422