### PR TITLE
fix tests with newer libcurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# pecl-web_services-oauth
+oauth consumer extension
+
+You probably shouldn't be using this extension. This is only for OAuth v1.

--- a/config.m4
+++ b/config.m4
@@ -17,7 +17,7 @@ if test "$PHP_OAUTH" != "no"; then
         AC_MSG_CHECKING(for cURL in default path)
         have_curl=no
         for i in /usr/local /usr; do
-          if test -r $i/include/curl/easy.h; then
+          if test -r $i/include/curl/easy.h -o -r $i/include/x86_64-linux-gnu/curl/easy.h; then
             have_curl=yes
             CURL_DIR=$i
             AC_MSG_RESULT(found in $i)

--- a/config.w32
+++ b/config.w32
@@ -5,10 +5,15 @@ ARG_WITH("oauth", "oAuth support", "no");
 if (PHP_OAUTH != "no") {
 	if (CHECK_LIB("libcurl_a.lib;libcurl.lib", "oauth", PHP_OAUTH) &&
 			CHECK_HEADER_ADD_INCLUDE("curl/easy.h", "CFLAGS_OAUTH") &&
-			CHECK_LIB("ssleay32.lib", "oauth", PHP_OAUTH) &&
-			CHECK_LIB("libeay32.lib", "oauth", PHP_OAUTH) 
+			(CHECK_LIB("libcrypto.lib", "oauth", PHP_OAUTH) &&
+			 CHECK_LIB("libssl.lib", "oauth", PHP_OAUTH) ||
+			 CHECK_LIB("ssleay32.lib", "oauth", PHP_OAUTH) &&
+			 CHECK_LIB("libeay32.lib", "oauth", PHP_OAUTH)) &&
+			CHECK_LIB("libssh2.lib", "oauth", PHP_OAUTH) &&
+			CHECK_LIB("nghttp2.lib", "oauth", PHP_OAUTH)
 		&& CHECK_LIB("winmm.lib", "oauth", PHP_OAUTH)
 		&& CHECK_LIB("wldap32.lib", "oauth", PHP_OAUTH)
+		&& CHECK_LIB("Normaliz.lib", "oauth", PHP_OAUTH)
 		&& (((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib", "oauth", PHP_OAUTH) ||  CHECK_LIB("zlib.lib", "oauth", PHP_OAUTH))) || 
 			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "oauth", PHP_OAUTH)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED)))
 		) {

--- a/oauth.c
+++ b/oauth.c
@@ -246,6 +246,7 @@ zend_string *soo_sign_rsa(php_so_object *soo, char *message, const oauth_sig_con
 	/* TODO: add support for other algorithms instead of OPENSSL_ALGO_SHA1 */
 
 	ZVAL_STRING(&args[0], message);
+	ZVAL_NULL(&args[1]);
 	ZVAL_DUP(&args[2], &ctx->privatekey);
 
 	call_user_function_ex(EG(function_table), NULL, &func, &retval, 3, args, 0, NULL);

--- a/oauth.c
+++ b/oauth.c
@@ -194,7 +194,6 @@ void soo_handle_error(php_so_object *soo, long errorCode, char *msg, char *respo
 }
 /* }}} */
 
-
 zend_string *soo_sign_hmac(php_so_object *soo, char *message, const char *cs, const char *ts, const oauth_sig_context *ctx) /* {{{ */
 {
 	zval args[4], retval, func;
@@ -232,7 +231,7 @@ zend_string *soo_sign_hmac(php_so_object *soo, char *message, const char *cs, co
 }
 /* }}} */
 
-zend_string *soo_sign_rsa(php_so_object *soo, char *message, const oauth_sig_context *ctx)
+zend_string *soo_sign_rsa(php_so_object *soo, char *message, const oauth_sig_context *ctx) /* {{{ */
 {
 	zval args[3], func, retval;
 	zend_string *result;
@@ -272,7 +271,7 @@ zend_string *soo_sign_plain(php_so_object *soo, const char *cs, const char *ts) 
 }
 /* }}} */
 
-oauth_sig_context *oauth_create_sig_context(const char *sigmethod)
+oauth_sig_context *oauth_create_sig_context(const char *sigmethod) /* {{{ */
 {
 	oauth_sig_context *ctx;
 
@@ -289,8 +288,9 @@ oauth_sig_context *oauth_create_sig_context(const char *sigmethod)
 
 	return ctx;
 }
+/* }}} */
 
-zend_string *soo_sign(php_so_object *soo, char *message, zval *cs, zval *ts, const oauth_sig_context *ctx)
+zend_string *soo_sign(php_so_object *soo, char *message, zval *cs, zval *ts, const oauth_sig_context *ctx) /* {{{ */
 {
 	const char *csec = cs?Z_STRVAL_P(cs):"", *tsec = ts?Z_STRVAL_P(ts):"";
 
@@ -303,6 +303,7 @@ zend_string *soo_sign(php_so_object *soo, char *message, zval *cs, zval *ts, con
 	}
 	return NULL;
 }
+/* }}} */
 
 static inline zval *soo_get_property(php_so_object *soo, char *prop_name) /* {{{ */
 {
@@ -338,7 +339,7 @@ zend_string *oauth_url_encode(char *url, int url_len) /* {{{ */
 }
 /* }}} */
 
-zend_string *oauth_http_encode_value(zval *v)
+zend_string *oauth_http_encode_value(zval *v) /* {{{ */
 {
 	zend_string *param_value = NULL;
 
@@ -354,8 +355,9 @@ zend_string *oauth_http_encode_value(zval *v)
 
 	return param_value;
 }
+/* }}} */
 
-static int oauth_strcmp(zval *first, zval *second)
+static int oauth_strcmp(zval *first, zval *second) /* {{{ */
 {
 	int result;
 	result = string_compare_function(first, second);
@@ -368,8 +370,9 @@ static int oauth_strcmp(zval *first, zval *second)
 
 	return 0;
 }
+/* }}} */
 
-static int oauth_compare_value(const void *a, const void *b)
+static int oauth_compare_value(const void *a, const void *b) /* {{{ */
 {
 	Bucket *f, *s;
 	f = (Bucket *)a;
@@ -377,8 +380,9 @@ static int oauth_compare_value(const void *a, const void *b)
 
 	return oauth_strcmp(&f->val, &s->val);
 }
+/* }}} */
 
-static int oauth_compare_key(const void *a, const void *b)
+static int oauth_compare_key(const void *a, const void *b) /* {{{ */
 {
 	zval first, second;
 	int result;
@@ -403,9 +407,10 @@ static int oauth_compare_key(const void *a, const void *b)
 	zval_ptr_dtor(&second);
 	return result;
 }
+/* }}} */
 
 /* build url-encoded string from args, optionally starting with & */
-int oauth_http_build_query(php_so_object *soo, smart_string *s, HashTable *args, zend_bool prepend_amp)
+int oauth_http_build_query(php_so_object *soo, smart_string *s, HashTable *args, zend_bool prepend_amp) /* {{{ */
 {
 	zval *cur_val;
 	zend_string *cur_key, *arg_key, *param_value;
@@ -535,9 +540,10 @@ int oauth_http_build_query(php_so_object *soo, smart_string *s, HashTable *args,
 	}
 	return numargs;
 }
+/* }}} */
 
 /* retrieves parameter value from the _GET or _POST superglobal */
-void get_request_param(char *arg_name, char **return_val, int *return_len)
+void get_request_param(char *arg_name, char **return_val, int *return_len) /* {{{ */
 {
 	zval *ptr;
 	if (
@@ -551,12 +557,12 @@ void get_request_param(char *arg_name, char **return_val, int *return_len)
 	*return_val = NULL;
 	*return_len = 0;
 }
+/* }}} */
 
 /*
  * This function does not currently care to respect parameter precedence, in the sense that if a common param is defined
  * in POST/GET or Authorization header, the precendence is defined by: OAuth Core 1.0 section 9.1.1
  */
-
 zend_string *oauth_generate_sig_base(php_so_object *soo, const char *http_method, const char *uri, HashTable *post_args, HashTable *extra_args) /* {{{ */
 {
 	zval params;
@@ -663,7 +669,8 @@ zend_string *oauth_generate_sig_base(php_so_object *soo, const char *http_method
 }
 /* }}} */
 
-static void oauth_set_debug_info(php_so_object *soo) {
+static void oauth_set_debug_info(php_so_object *soo) /* {{{ */
+{
 	zval *debugInfo;
 	if (soo->debug_info) {
 		debugInfo = &soo->debugArr;
@@ -688,6 +695,7 @@ static void oauth_set_debug_info(php_so_object *soo) {
 		ZVAL_UNDEF(&soo->debugArr);
 	}
 }
+/* }}} */
 
 static int add_arg_for_req(HashTable *ht, const char *arg, const char *val) /* {{{ */
 {
@@ -700,7 +708,7 @@ static int add_arg_for_req(HashTable *ht, const char *arg, const char *val) /* {
 }
 /* }}} */
 
-void oauth_add_signature_header(HashTable *request_headers, HashTable *oauth_args, smart_string *header)
+void oauth_add_signature_header(HashTable *request_headers, HashTable *oauth_args, smart_string *header) /* {{{ */
 {
 	smart_string sheader = {0};
 	zend_bool prepend_comma = FALSE;
@@ -743,6 +751,7 @@ void oauth_add_signature_header(HashTable *request_headers, HashTable *oauth_arg
 	}
 	smart_string_free(&sheader);
 }
+/* }}} */
 
 #define HTTP_RESPONSE_CAAS(zvalp, header, storkey) { \
 	if (0==strncasecmp(Z_STRVAL_P(zvalp),header,sizeof(header)-1)) { \
@@ -987,7 +996,7 @@ int oauth_debug_handler(CURL *ch, curl_infotype type, char *data, size_t data_le
 }
 /* }}} */
 
-static size_t soo_read_header(void *ptr, size_t size, size_t nmemb, void *ctx)
+static size_t soo_read_header(void *ptr, size_t size, size_t nmemb, void *ctx) /* {{{ */
 {
 	char *header;
 	size_t hlen, vpos = sizeof("Location:") - 1;
@@ -1023,6 +1032,7 @@ static size_t soo_read_header(void *ptr, size_t size, size_t nmemb, void *ctx)
 	}
 	return hlen;
 }
+/* }}} */
 
 long make_req_curl(php_so_object *soo, const char *url, const smart_string *payload, const char *http_method, HashTable *request_headers) /* {{{ */
 {
@@ -1655,6 +1665,8 @@ static long oauth_fetch(php_so_object *soo, const char *url, const char *method,
 }
 /* }}} */
 
+/* {{{ proto bool setRSACertificate(string $cert)
+       Sets the RSA certificate */
 SO_METHOD(setRSACertificate)
 {
 	char *key;
@@ -1688,6 +1700,7 @@ SO_METHOD(setRSACertificate)
 		return;
 	}
 }
+/* }}} */
 
 /* {{{ proto string oauth_urlencode(string uri)
    URI encoding according to RFC 3986, note: is not utf8 capable until the underlying phpapi is */
@@ -1859,7 +1872,7 @@ SO_METHOD(__construct)
 }
 /* }}} */
 
-void oauth_free_privatekey(zval *privatekey)
+void oauth_free_privatekey(zval *privatekey) /* {{{ */
 {
 	zval func, retval;
 	zval args[1];
@@ -1876,6 +1889,7 @@ void oauth_free_privatekey(zval *privatekey)
 
 	zval_ptr_dtor(privatekey);
 }
+/* }}} */
 
 /* {{{ proto array OAuth::setCAPath(string ca_path, string ca_info)
    Set the Certificate Authority information */
@@ -2109,7 +2123,6 @@ SO_METHOD(disableSSLChecks)
 }
 /* }}} */
 
-
 /* {{{ proto bool OAuth::setSSLChecks(long sslcheck)
    Tweak specific SSL checks for requests (be careful using this for production) */
 SO_METHOD(setSSLChecks)
@@ -2133,7 +2146,6 @@ SO_METHOD(setSSLChecks)
 	RETURN_TRUE;
 }
 /* }}} */
-
 
 /* {{{ proto bool OAuth::setVersion(string version)
    Set oauth_version for requests (default 1.0) */
@@ -2248,6 +2260,8 @@ SO_METHOD(setNonce)
 }
 /* }}} */
 
+/* {{{ proto bool setTimestamp(string $timestamp)
+Sets the OAuth timestamp for subsequent requests */
 SO_METHOD(setTimestamp)
 {
 	php_so_object *soo;
@@ -2272,6 +2286,7 @@ SO_METHOD(setTimestamp)
 
 	RETURN_TRUE;
 }
+/* }}} */
 
 /* {{{ proto bool OAuth::setToken(string token, string token_secret)
    Set a request or access token and token secret to be used in subsequent requests */
@@ -2487,6 +2502,8 @@ SO_METHOD(getLastResponse)
 }
 /* }}} */
 
+/* {{{ proto string getLastResponseHeaders(void)
+Get headers for last response */
 SO_METHOD(getLastResponseHeaders)
 {
 	php_so_object *soo;
@@ -2501,6 +2518,7 @@ SO_METHOD(getLastResponseHeaders)
 	}
 	RETURN_FALSE;
 }
+/* }}} */
 
 /* {{{ proto string OAuth::getRequestHeader(string http_method, string url [, string|array extra_parameters ])
    Generate OAuth header string signature based on the final HTTP method, URL and a string/array of parameters */

--- a/oauth.c
+++ b/oauth.c
@@ -1044,7 +1044,7 @@ long make_req_curl(php_so_object *soo, const char *url, const smart_string *payl
 	double d_code;
 	zval info, *zca_info, *zca_path, *cur_val;
 	char *s_code, *content_type = NULL, *bufz = NULL;
-	uit32_t sslcheck;
+	uint32_t sslcheck;
 	zend_ulong num_key;
 	smart_string sheader = {0};
 	zend_string *cur_key;
@@ -1412,7 +1412,7 @@ static long oauth_fetch(php_so_object *soo, const char *url, const char *method,
 	HashTable *rargs = NULL, *rheaders = NULL;
 	long http_response_code, auth_type;
 	smart_string surl = {0}, payload = {0}, postdata = {0};
-	uit32_t is_redirect = FALSE, follow_redirects = 0, need_to_free_rheaders = 0;
+	uint32_t is_redirect = FALSE, follow_redirects = 0, need_to_free_rheaders = 0;
 
 	auth_type = Z_LVAL_P(soo_get_property(soo, OAUTH_ATTR_AUTHMETHOD));
 	if(fetch_flags & OAUTH_OVERRIDE_HTTP_METHOD) {

--- a/oauth.c
+++ b/oauth.c
@@ -1451,7 +1451,7 @@ static long oauth_fetch(php_so_object *soo, const char *url, const char *method,
 	}
 
 	/* additional http headers can be passed */
-	if (!request_headers) {
+	if (!request_headers || !zend_hash_num_elements(Z_ARRVAL_P(request_headers))) {
 		ALLOC_HASHTABLE(rheaders);
 		zend_hash_init(rheaders, 0, NULL, ZVAL_PTR_DTOR, 0);
 		need_to_free_rheaders = 1;

--- a/oauth.c
+++ b/oauth.c
@@ -709,13 +709,14 @@ void oauth_add_signature_header(HashTable *request_headers, HashTable *oauth_arg
 	zend_string *param_name, *param_val;
 	zend_string *cur_key;
 	ulong num_key;
+	HashPosition pos;
 
 	smart_string_appends(&sheader, "OAuth ");
 
-	for (zend_hash_internal_pointer_reset(oauth_args);
-			(curval = zend_hash_get_current_data(oauth_args)) != NULL;
-			zend_hash_move_forward(oauth_args)) {
-		zend_hash_get_current_key(oauth_args, &cur_key, &num_key);
+	for (zend_hash_internal_pointer_reset_ex(oauth_args, &pos);
+			(curval = zend_hash_get_current_data_ex(oauth_args, &pos)) != NULL;
+				zend_hash_move_forward_ex(oauth_args, &pos)) {
+		zend_hash_get_current_key_ex(oauth_args, &cur_key, &num_key, &pos);
 
 		if (prepend_comma) {
 			smart_string_appendc(&sheader, ',');
@@ -780,8 +781,8 @@ static long make_req_streams(php_so_object *soo, const char *url, const smart_st
 	sc = php_stream_context_alloc();
 
 	if (payload->len) {
-		smart_string_0(payload);
 		ZVAL_STRINGL(&zpayload, payload->c, payload->len);
+		Z_STRVAL(zpayload)[Z_STRLEN(zpayload)] = '\0';
 		php_stream_context_set_option(sc, "http", "content", &zpayload);
 		zval_ptr_dtor(&zpayload);
 		/**
@@ -1036,6 +1037,7 @@ long make_req_curl(php_so_object *soo, const char *url, const smart_string *payl
 	ulong num_key;
 	smart_string sheader = {0};
 	zend_string *cur_key;
+	HashPosition pos;
 
 	zca_info = soo_get_property(soo, OAUTH_ATTR_CA_INFO);
 	zca_path = soo_get_property(soo, OAUTH_ATTR_CA_PATH);
@@ -1044,11 +1046,11 @@ long make_req_curl(php_so_object *soo, const char *url, const smart_string *payl
 	curl = curl_easy_init();
 
 	if (request_headers) {
-		for (zend_hash_internal_pointer_reset(request_headers);
-				(cur_val = zend_hash_get_current_data(request_headers)) != NULL;
-				zend_hash_move_forward(request_headers)) {
+		for (zend_hash_internal_pointer_reset_ex(request_headers, &pos);
+				(cur_val = zend_hash_get_current_data_ex(request_headers, &pos)) != NULL;
+				zend_hash_move_forward_ex(request_headers, &pos)) {
 			/* check if a string based key is used */
-			switch (zend_hash_get_current_key(request_headers, &cur_key, &num_key)) {
+			switch (zend_hash_get_current_key_ex(request_headers, &cur_key, &num_key, &pos)) {
 				case HASH_KEY_IS_STRING:
 					smart_string_appendl(&sheader, ZSTR_VAL(cur_key), ZSTR_LEN(cur_key));
 					break;

--- a/oauth.c
+++ b/oauth.c
@@ -416,7 +416,7 @@ int oauth_http_build_query(php_so_object *soo, smart_string *s, HashTable *args,
 	zval *cur_val;
 	zend_string *cur_key, *arg_key, *param_value;
 	int numargs = 0, hash_key_type, skip_append = 0, i, found;
-	ulong num_index;
+	zend_ulong num_index;
 	HashPosition pos;
 	smart_string keyname;
 
@@ -717,7 +717,7 @@ void oauth_add_signature_header(HashTable *request_headers, HashTable *oauth_arg
 	zval *curval;
 	zend_string *param_name, *param_val;
 	zend_string *cur_key;
-	ulong num_key;
+	zend_ulong num_key;
 	HashPosition pos;
 
 	smart_string_appends(&sheader, "OAuth ");
@@ -806,7 +806,7 @@ static long make_req_streams(php_so_object *soo, const char *url, const smart_st
 		HashPosition pos;
 		zval *cur_val, zheaders;
 		zend_string *cur_key;
-		ulong num_key;
+		zend_ulong num_key;
 		smart_string sheaders = {0};
 		int first = 1;
 
@@ -945,7 +945,7 @@ static long make_req_streams(php_so_object *soo, const char *url, const smart_st
 #if OAUTH_USE_CURL
 static size_t soo_read_response(char *ptr, size_t size, size_t nmemb, void *ctx) /* {{{ */
 {
-	uint relsize;
+	size_t relsize;
 	php_so_object *soo = (php_so_object *)ctx;
 
 	relsize = size * nmemb;
@@ -1044,8 +1044,8 @@ long make_req_curl(php_so_object *soo, const char *url, const smart_string *payl
 	double d_code;
 	zval info, *zca_info, *zca_path, *cur_val;
 	char *s_code, *content_type = NULL, *bufz = NULL;
-	uint sslcheck;
-	ulong num_key;
+	uit32_t sslcheck;
+	zend_ulong num_key;
 	smart_string sheader = {0};
 	zend_string *cur_key;
 	HashPosition pos;
@@ -1412,7 +1412,7 @@ static long oauth_fetch(php_so_object *soo, const char *url, const char *method,
 	HashTable *rargs = NULL, *rheaders = NULL;
 	long http_response_code, auth_type;
 	smart_string surl = {0}, payload = {0}, postdata = {0};
-	uint is_redirect = FALSE, follow_redirects = 0, need_to_free_rheaders = 0;
+	uit32_t is_redirect = FALSE, follow_redirects = 0, need_to_free_rheaders = 0;
 
 	auth_type = Z_LVAL_P(soo_get_property(soo, OAUTH_ATTR_AUTHMETHOD));
 	if(fetch_flags & OAUTH_OVERRIDE_HTTP_METHOD) {

--- a/package.xml
+++ b/package.xml
@@ -159,6 +159,7 @@ Requirements: ext/hash (now a part of PHP core)
   <changelog>
 
   <release>
+<<<<<<< HEAD
     <date>2019-12-02</date>
     <version>
       <release>2.0.4</release>
@@ -192,8 +193,11 @@ Requirements: ext/hash (now a part of PHP core)
 
   <release>
     <date>2018-06-28</date>
+=======
+    <date>2018-09-30</date>
+>>>>>>> Fix package.xml and update version for 2.0.4
     <version>
-      <release>2.0.2</release>
+      <release>2.0.3</release>
       <api>2.0</api>
     </version>
     <stability>
@@ -202,9 +206,7 @@ Requirements: ext/hash (now a part of PHP core)
     </stability>
     <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
     <notes>
-      * Fix bug #74163: Segfault in oauth_compare_value
-      * Fix bug #73434: Null byte at end of array keys in getLastResponseInfo
-      * Fix compatibility with PHP 7.3
+      * Use _ex versions to avoid SIGABRT of during use of hash functions in 7.2+ (Derick Rethans)
     </notes>
   </release>
 
@@ -220,6 +222,9 @@ Requirements: ext/hash (now a part of PHP core)
     </stability>
     <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
     <notes>
+      * Fix bug #74163: Segfault in oauth_compare_value
+      * Fix bug #73434: Null byte at end of array keys in getLastResponseInfo
+      * Fix compatibility with PHP 7.3
       * Fix #72006
     </notes>
   </release>

--- a/package.xml
+++ b/package.xml
@@ -188,6 +188,9 @@ Requirements: ext/hash (now a part of PHP core)
     <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
     <notes>
       * Use _ex versions to avoid SIGABRT of during use of hash functions in 7.2+ (Derick Rethans)
+      * Fix bug #74163: Segfault in oauth_compare_value
+      * Fix bug #73434: Null byte at end of array keys in getLastResponseInfo
+      * Fix compatibility with PHP 7.3
     </notes>
   </release>
 
@@ -222,9 +225,6 @@ Requirements: ext/hash (now a part of PHP core)
     </stability>
     <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
     <notes>
-      * Fix bug #74163: Segfault in oauth_compare_value
-      * Fix bug #73434: Null byte at end of array keys in getLastResponseInfo
-      * Fix compatibility with PHP 7.3
       * Fix #72006
     </notes>
   </release>

--- a/package.xml
+++ b/package.xml
@@ -160,6 +160,7 @@ Requirements: ext/hash (now a part of PHP core)
 
   <release>
 <<<<<<< HEAD
+<<<<<<< HEAD
     <date>2019-12-02</date>
     <version>
       <release>2.0.4</release>
@@ -178,6 +179,10 @@ Requirements: ext/hash (now a part of PHP core)
   <release>
     <date>2018-09-30</date>
     <version>
+=======
+    <date>2018-09-30</date>
+    <version>
+>>>>>>> Fix package.xml and update version for 2.0.4
       <release>2.0.3</release>
       <api>2.0</api>
     </version>
@@ -188,9 +193,12 @@ Requirements: ext/hash (now a part of PHP core)
     <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
     <notes>
       * Use _ex versions to avoid SIGABRT of during use of hash functions in 7.2+ (Derick Rethans)
+<<<<<<< HEAD
       * Fix bug #74163: Segfault in oauth_compare_value
       * Fix bug #73434: Null byte at end of array keys in getLastResponseInfo
       * Fix compatibility with PHP 7.3
+=======
+>>>>>>> Fix package.xml and update version for 2.0.4
     </notes>
   </release>
 
@@ -225,6 +233,9 @@ Requirements: ext/hash (now a part of PHP core)
     </stability>
     <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
     <notes>
+      * Fix bug #74163: Segfault in oauth_compare_value
+      * Fix bug #73434: Null byte at end of array keys in getLastResponseInfo
+      * Fix compatibility with PHP 7.3
       * Fix #72006
     </notes>
   </release>

--- a/php_oauth.h
+++ b/php_oauth.h
@@ -216,12 +216,12 @@ typedef struct {
 	smart_string headers_in;
 	smart_string headers_out;
 	char last_location_header[OAUTH_MAX_HEADER_LEN];
-	uit32_t redirects;
-	uit32_t multipart_files_num;
-	uit32_t sslcheck; /* whether we check for SSL verification or not */
-	uit32_t debug; /* verbose output */
-	uit32_t follow_redirects; /* follow and sign redirects? */
-	uit32_t reqengine; /* streams or curl */
+	uint32_t redirects;
+	uint32_t multipart_files_num;
+	uint32_t sslcheck; /* whether we check for SSL verification or not */
+	uint32_t debug; /* verbose output */
+	uint32_t follow_redirects; /* follow and sign redirects? */
+	uint32_t reqengine; /* streams or curl */
 	long timeout; /* timeout in milliseconds */
 	char *nonce;
 	char *timestamp;
@@ -232,7 +232,7 @@ typedef struct {
 	php_so_debug *debug_info;
 	char **multipart_files;
 	char **multipart_params;
-	uit32_t is_multipart;
+	uint32_t is_multipart;
 	void ***thread_ctx;
 	zend_object zo;
 } php_so_object;

--- a/php_oauth.h
+++ b/php_oauth.h
@@ -216,12 +216,12 @@ typedef struct {
 	smart_string headers_in;
 	smart_string headers_out;
 	char last_location_header[OAUTH_MAX_HEADER_LEN];
-	uint redirects;
-	uint multipart_files_num;
-	uint sslcheck; /* whether we check for SSL verification or not */
-	uint debug; /* verbose output */
-	uint follow_redirects; /* follow and sign redirects? */
-	uint reqengine; /* streams or curl */
+	uit32_t redirects;
+	uit32_t multipart_files_num;
+	uit32_t sslcheck; /* whether we check for SSL verification or not */
+	uit32_t debug; /* verbose output */
+	uit32_t follow_redirects; /* follow and sign redirects? */
+	uit32_t reqengine; /* streams or curl */
 	long timeout; /* timeout in milliseconds */
 	char *nonce;
 	char *timestamp;
@@ -232,7 +232,7 @@ typedef struct {
 	php_so_debug *debug_info;
 	char **multipart_files;
 	char **multipart_params;
-	uint is_multipart;
+	uit32_t is_multipart;
 	void ***thread_ctx;
 	zend_object zo;
 } php_so_object;

--- a/provider.c
+++ b/provider.c
@@ -58,7 +58,7 @@ static int oauth_provider_remove_required_param(HashTable *ht, char *required_pa
 {
 	zval *dest_entry;
 	zend_string *key;
-	ulong num_key;
+	zend_ulong num_key;
 	HashPosition hpos;
 
 	if((dest_entry = zend_hash_str_find(ht, required_param, strlen(required_param))) == NULL) {
@@ -97,7 +97,7 @@ static void oauth_provider_apply_custom_param(HashTable *ht, HashTable *custom) 
 	HashPosition custompos;
 	zval *entry;
 	zend_string *key;
-	ulong num_key;
+	zend_ulong num_key;
 
 	zend_hash_internal_pointer_reset_ex(custom, &custompos);
 	do {
@@ -156,7 +156,7 @@ static void oauth_provider_check_required_params(HashTable *required_params, Has
 	HashPosition hpos, reqhpos, paramhpos;
 	zval *dest_entry, param;
 	zend_string *key;
-	ulong num_key;
+	zend_ulong num_key;
 
 	zend_hash_internal_pointer_reset_ex(required_params, &hpos);
 	zend_hash_internal_pointer_reset_ex(params, &reqhpos);
@@ -451,7 +451,7 @@ SOP_METHOD(__construct)
 	zval *params = NULL, *pthis = NULL, apache_get_headers, retval, *tmpzval, *item_param;
 	char *authorization_header = NULL;
 	zend_string *key;
-	ulong num_key = 0, param_count = 0;
+	zend_ulong num_key = 0, param_count = 0;
 	HashPosition hpos;
 
 	pthis = getThis();
@@ -662,7 +662,7 @@ SOP_METHOD(checkOAuthRequest)
 	zval *retval = NULL, *param, *pthis, *token_secret = NULL, *consumer_secret, *req_signature, *sig_method = NULL, rv;
 	oauth_sig_context *sig_ctx = NULL;
 	php_oauth_provider *sop;
-	ulong missing_param_count = 0, mp_count = 1;
+	zend_ulong missing_param_count = 0, mp_count = 1;
 	char additional_info[512] = "", *http_verb = NULL, *uri = NULL, *current_uri = NULL;
 	zend_string *sbs, *signature = NULL;
 	HashPosition hpos;
@@ -974,8 +974,8 @@ SOP_METHOD(reportProblem)
 	zend_bool out_malloced = 0;
 	char *out, *tmp_out, *http_header_line;
 	size_t pr_len;
-	ulong lcode;
-	uint http_code;
+	zend_ulong lcode;
+	uit32_t http_code;
 	sapi_header_line ctr = {0};
 	zend_bool send_headers = 1;
 

--- a/provider.c
+++ b/provider.c
@@ -975,7 +975,7 @@ SOP_METHOD(reportProblem)
 	char *out, *tmp_out, *http_header_line;
 	size_t pr_len;
 	zend_ulong lcode;
-	uit32_t http_code;
+	uint32_t http_code;
 	sapi_header_line ctr = {0};
 	zend_bool send_headers = 1;
 

--- a/tests/bug16946.phpt
+++ b/tests/bug16946.phpt
@@ -42,20 +42,17 @@ array(2) {
   string(4) "4567"
 }
 string(%d) "GET /test HTTP/%f
-User-Agent: PECL-OAuth/%f%s
-Host: 127.0.0.1:12342
+%a
 Accept: */*
 Authorization: OAuth oauth_consumer_key="1234",oauth_signature_method="HMAC-SHA1",oauth_nonce="%s.%d",oauth_timestamp="%d",oauth_version="1.0",oauth_signature="%s"
 
 GET /some_url_that_goes_nowhere_and_could_be_very_long.html?bla=bla&mekker=mekker HTTP/%f
-User-Agent: PECL-OAuth/%f%s
-Host: 127.0.0.1:12342
+%a
 Accept: */*
 Authorization: OAuth oauth_consumer_key="1234",oauth_signature_method="HMAC-SHA1",oauth_nonce="%s.%d",oauth_timestamp="%d",oauth_version="1.0",oauth_signature="%s"
 
 GET /some_other_url.html HTTP/%f
-User-Agent: PECL-OAuth/%f%s
-Host: 127.0.0.1:12342
+%a
 Accept: */*
 Authorization: OAuth oauth_consumer_key="1234",oauth_signature_method="HMAC-SHA1",oauth_nonce="%s.%d",oauth_timestamp="%d",oauth_version="1.0",oauth_signature="%s"
 

--- a/tests/overflow_redir.phpt
+++ b/tests/overflow_redir.phpt
@@ -41,14 +41,12 @@ array(2) {
   string(4) "4567"
 }
 string(%d) "GET /test HTTP/%f
-User-Agent: PECL-OAuth/%f%s
-Host: 127.0.0.1:12342
+%a
 Accept: */*
 Authorization: OAuth oauth_consumer_key="1234",oauth_signature_method="HMAC-SHA1",oauth_nonce="%s.%d",oauth_timestamp="%d",oauth_version="1.0",oauth_signature="%s"
 
 GET /aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa HTTP/%f
-User-Agent: PECL-OAuth/%f%s
-Host: 127.0.0.1:12342
+%a
 Accept: */*
 Authorization: OAuth oauth_consumer_key="1234",oauth_signature_method="HMAC-SHA1",oauth_nonce="%s.%d",oauth_timestamp="%d",oauth_version="1.0",oauth_signature="%s"
 


### PR DESCRIPTION
libcurl changed the order in which headers like User-Agent and Host are
sent, so do not depend on a specific order of those headers