### PR TITLE
Fix config.w32

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -5,10 +5,13 @@ ARG_WITH("oauth", "oAuth support", "no");
 if (PHP_OAUTH != "no") {
 	if (CHECK_LIB("libcurl_a.lib;libcurl.lib", "oauth", PHP_OAUTH) &&
 			CHECK_HEADER_ADD_INCLUDE("curl/easy.h", "CFLAGS_OAUTH") &&
-			CHECK_LIB("ssleay32.lib", "oauth", PHP_OAUTH) &&
-			CHECK_LIB("libeay32.lib", "oauth", PHP_OAUTH) 
+			CHECK_LIB("libssl.lib;ssleay32.lib", "oauth", PHP_OAUTH) &&
+			CHECK_LIB("libcrypto.lib;libeay32.lib", "oauth", PHP_OAUTH) 
 		&& CHECK_LIB("winmm.lib", "oauth", PHP_OAUTH)
 		&& CHECK_LIB("wldap32.lib", "oauth", PHP_OAUTH)
+		&& CHECK_LIB("libssh2.lib;libssh2_a.lib", "oauth", PHP_OAUTH)
+		&& CHECK_LIB("nghttp2.lib;nghttp2_a.lib", "oauth", PHP_OAUTH)
+		&& CHECK_LIB("normaliz.lib", "oauth", PHP_OAUTH)
 		&& (((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib", "oauth", PHP_OAUTH) ||  CHECK_LIB("zlib.lib", "oauth", PHP_OAUTH))) || 
 			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "oauth", PHP_OAUTH)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED)))
 		) {


### PR DESCRIPTION
The DLLs have been renamed as of OpenSSL 1.1.0, so we need to check for
the new names as well.

We also have to check for dependencies of libcurl.

--- 
These fixes are required for the PECL builds. 2.0.4 just failed because of not having them.