### PR TITLE
Replace HAVE_OPENSSL_EXT with zend_hash_str_exists

### DIFF
--- a/oauth.c
+++ b/oauth.c
@@ -2854,11 +2854,11 @@ PHP_MINFO_FUNCTION(oauth)
 	php_info_print_table_start();
 	php_info_print_table_header(2, "OAuth support", "enabled");
 	php_info_print_table_row(2, "PLAINTEXT support", "enabled");
-#if HAVE_OPENSSL_EXT
+if (zend_hash_str_exists(&module_registry, "openssl", sizeof("openssl")-1)) {
 	php_info_print_table_row(2, "RSA-SHA1 support", "enabled");
-#else
+} else {
 	php_info_print_table_row(2, "RSA-SHA1 support", "not supported");
-#endif
+}
 	php_info_print_table_row(2, "HMAC-SHA1 support", "enabled");
 #if OAUTH_USE_CURL
 	php_info_print_table_row(2, "Request engine support", "php_streams, curl");


### PR DESCRIPTION
This replaces the HAVE_OPENSSL_EXT condition with more reliable zend_hash_str_exists. If the openssl extension is loaded as a shared module on *nix, this symbol is also defined but openssl shared object (openssl.so) might not be loaded at the runtime.

See: https://github.com/php/php-src/pull/14333