### PR TITLE
fix for PHP 8.4

### DIFF
--- a/oauth.c
+++ b/oauth.c
@@ -1330,7 +1330,7 @@ static void make_standard_query(HashTable *ht, php_so_object *soo) /* {{{ */
 		gettimeofday((struct timeval *) &tv, (struct timezone *) NULL);
 		sec = (int) tv.tv_sec;
 		usec = (int) (tv.tv_usec % 0x100000);
-		spprintf(&nonce, 0, "%ld%08x%05x%.8f", php_rand(), sec, usec, php_combined_lcg() * 10);
+		spprintf(&nonce, 0, "%d%08x%05x%.8f", php_mt_rand(), sec, usec, php_combined_lcg() * 10);
 	}
 
 	add_arg_for_req(ht, OAUTH_PARAM_CONSUMER_KEY, Z_STRVAL_P(soo_get_property(soo, OAUTH_ATTR_CONSUMER_KEY)));

--- a/oauth.c
+++ b/oauth.c
@@ -599,8 +599,8 @@ zend_string *oauth_generate_sig_base(php_so_object *soo, const char *http_method
 			php_url_free(urlparts);
 			return NULL;
 		}
-		php_strtolower(OAUTH_URL_STR(urlparts->scheme), OAUTH_URL_LEN(urlparts->scheme));
-		php_strtolower(OAUTH_URL_STR(urlparts->host), OAUTH_URL_LEN(urlparts->host));
+		zend_str_tolower(OAUTH_URL_STR(urlparts->scheme), OAUTH_URL_LEN(urlparts->scheme));
+		zend_str_tolower(OAUTH_URL_STR(urlparts->host), OAUTH_URL_LEN(urlparts->host));
 		smart_string_appends(&sbuf, OAUTH_URL_STR(urlparts->scheme));
 		smart_string_appends(&sbuf, "://");
 		smart_string_appends(&sbuf, OAUTH_URL_STR(urlparts->host));

--- a/php_oauth.h
+++ b/php_oauth.h
@@ -29,7 +29,12 @@
 #include "php_main.h"
 #include "php_ini.h"
 #include "ext/standard/php_string.h"
+#if PHP_VERSION_ID < 80400
 #include "ext/standard/php_rand.h"
+#include "ext/standard/php_lcg.h"
+#else
+#include "ext/random/php_random.h"
+#endif
 #include "ext/standard/php_smart_string.h"
 #include "ext/standard/info.h"
 #include "ext/standard/php_string.h"
@@ -41,7 +46,6 @@
 #include "php_globals.h"
 #include "ext/standard/file.h"
 #include "ext/standard/base64.h"
-#include "ext/standard/php_lcg.h"
 #include "ext/pcre/php_pcre.h"
 #include "php_network.h"
 

--- a/provider.c
+++ b/provider.c
@@ -235,8 +235,12 @@ static int oauth_provider_parse_auth_header(php_oauth_provider *sop, char *auth_
 #endif
 		&return_value,
 		&subpats,
+#if PHP_VERSION_ID < 80400
 		1, /* global */
 		1, /* use flags */
+#else
+		true, /* global */
+#endif
 		2, /* PREG_SET_ORDER */
 		0
 	);
@@ -956,7 +960,7 @@ SOP_METHOD(generateToken)
 			php_error_docref(NULL, E_WARNING, "Could not gather enough random data, falling back on rand()");
 		}
 		while (reaped < size) {
-			iv[reaped++] = (char) (255.0 * php_rand() / RAND_MAX);
+			iv[reaped++] = (char)php_mt_rand_range(0, 255);
 		}
 	}
 


### PR DESCRIPTION
```
* The backwards compatibility headers ext/standard/{php_lcg.h,php_mt_rand.h,
  php_rand.h,php_random.h} have been removed. Include ext/random/php_random.h
  directly.

* php_pcre_match_impl() now no longer has a use_flags argument.
     When flags should be ignored, pass 0 to the flags argument.

```