### PR TITLE
drop support for 7.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -172,10 +172,10 @@ Requirements: ext/hash (now a part of PHP core)
   <dependencies>
     <required>
       <php>
-        <min>7.0.0</min>
+        <min>7.1.0</min>
       </php>
       <pearinstaller>
-        <min>1.4.0b1</min>
+        <min>1.10.0</min>
       </pearinstaller>
       <extension>
         <name>hash</name>


### PR DESCRIPTION
Broken by e7f262becf3feb65c8195fff4591d9dbd8acbace

Sorry my fault: `php_mt_rand_range` appears in 7.1

BTW no CI, and test suite failing with 7.0 which is EOL for a while
So seems simpler to not support it anymore

```
=====================================================================
PHP_VERSION : 7.0.33
=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
OAuth getRequestToken [tests/bug16946.phpt]
OAuth getRequestToken [tests/oauth_reqtoken.phpt]
OAuth Standard functions [tests/oauth_standard.phpt]
OAuth Overflow in header redirect [tests/overflow_redir.phpt]
OAuth getRequestToken [tests/reqtoken_bug44603.phpt]
=====================================================================

```