### PR TITLE
arg_separators.input is an zend_string in 8.5

### DIFF
--- a/oauth.c
+++ b/oauth.c
@@ -60,7 +60,11 @@ static int oauth_parse_str(char *params, zval *dest_array) /* {{{ */
 	}
 
 	res = params;
+#if PHP_VERSION_ID < 80500
 	separator = (char *) estrdup(PG(arg_separator).input);
+#else
+	separator = (char *) estrdup(ZSTR_VAL(PG(arg_separator).input));
+#endif
 	var = php_strtok_r(res, separator, &strtok_buf);
 	while (var) {
 		val = strchr(var, '=');


### PR DESCRIPTION
Using 8.5.0alpha1

```
/dev/shm/BUILD/php85-php-pecl-oauth-2.0.9-build/php85-php-pecl-oauth-2.0.9/oauth-2.0.9/oauth.c: In function 'oauth_parse_str':
/dev/shm/BUILD/php85-php-pecl-oauth-2.0.9-build/php85-php-pecl-oauth-2.0.9/oauth-2.0.9/oauth.c:63:55: error: passing argument 1 of '_estrdup' from incompatible pointer type [-Wincompatible-pointer-types]
   63 |         separator = (char *) estrdup(PG(arg_separator).input);
/opt/remi/php85/root/usr/include/php/Zend/zend_alloc.h:164:83: note: in definition of macro 'estrdup'
  164 | #define estrdup(s)                                                      _estrdup((s) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
      |                                                                                   ^
/opt/remi/php85/root/usr/include/php/Zend/zend_alloc.h:76:74: note: expected 'const char *' but argument is of type 'zend_string *' {aka 'struct _zend_string *'}
   76 | ZEND_API ZEND_ATTRIBUTE_MALLOC char*  ZEND_FASTCALL _estrdup(const char *s ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
      |                                                              ~~~~~~~~~~~~^

```